### PR TITLE
Fix floating-point precision

### DIFF
--- a/lib/block.ex
+++ b/lib/block.ex
@@ -2,6 +2,7 @@ defmodule UltraDark.Blockchain.Block do
   alias UltraDark.Blockchain.Block
   alias UltraDark.Utilities
   alias UltraDark.Transaction
+  alias Decimal, as: D
 
   defstruct [
     index: nil,
@@ -100,12 +101,13 @@ defmodule UltraDark.Blockchain.Block do
     (:math.pow(16, 64 - difficulty) |> round) - 1
   end
 
-  @spec calculate_block_reward(number) :: number
+  @spec calculate_block_reward(number) :: Decimal
   def calculate_block_reward(block_index) do
-    100 / :math.pow(2, Integer.floor_div(block_index, 200000))
+    D.div(D.new(100), D.new(:math.pow(2, Integer.floor_div(block_index, 200000))))
   end
 
+  @spec total_block_fees(list) :: Decimal
   def total_block_fees(transactions) do
-    transactions |> Enum.reduce(0, fn tx, acc -> acc + Transaction.calculate_fee(tx) end)
+    transactions |> Enum.reduce(D.new(0), fn tx, acc -> D.add(acc, Transaction.calculate_fee(tx)) end)
   end
 end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -1,17 +1,19 @@
 defmodule UltraDark.Transaction do
   alias UltraDark.Transaction
   alias UltraDark.Utilities
+  alias Decimal, as: D
+
   defstruct [
     id: nil,
     inputs: [],
     outputs: [],
-    fee: 0,
+    fee: D.new(0),
     designations: [],
     timestamp: nil,
     txtype: "P2PK" # Most transactions will be pay-to-public-key
   ]
 
-  @spec calculate_outputs(Transaction) :: %{outputs: list, fee: float}
+  @spec calculate_outputs(Transaction) :: %{outputs: list, fee: Decimal}
   def calculate_outputs(transaction) do
     %{designations: designations} = transaction
 
@@ -43,7 +45,7 @@ defmodule UltraDark.Transaction do
     This coinbase has a single output, designated to the address of the miner, and the output amount is
     the block reward plus any transaction fees from within the transaction
   """
-  @spec generate_coinbase(float, String.t) :: Transaction
+  @spec generate_coinbase(Decimal, String.t) :: Transaction
   def generate_coinbase(amount, miner_address) do
     timestamp = DateTime.utc_now |> DateTime.to_string
     txid = Utilities.sha_base16(miner_address <> timestamp)
@@ -58,13 +60,13 @@ defmodule UltraDark.Transaction do
     }
   end
 
-  @spec sum_inputs(list) :: number
+  @spec sum_inputs(list) :: Decimal
   def sum_inputs(inputs) do
-    Enum.reduce(inputs, 0, fn (%{amount: amount}, acc) -> amount + acc end)
+    Enum.reduce(inputs, D.new(0), fn (%{amount: amount}, acc) -> D.add(amount, acc) end)
   end
 
-  @spec calculate_fee(Transaction) :: float
+  @spec calculate_fee(Transaction) :: Decimal
   def calculate_fee(transaction) do
-    sum_inputs(transaction.inputs) - sum_inputs(transaction.designations)
+    D.sub(sum_inputs(transaction.inputs), sum_inputs(transaction.designations))
   end
 end

--- a/lib/utilities.ex
+++ b/lib/utilities.ex
@@ -1,5 +1,4 @@
 defmodule UltraDark.Utilities do
-
   def sha_base16(input), do: :crypto.hash(:sha256, input) |> Base.encode16
 
   def sha3_base16(list) when is_list(list), do: sha3_base16(Enum.join(list))

--- a/lib/utilities.ex
+++ b/lib/utilities.ex
@@ -8,7 +8,6 @@ defmodule UltraDark.Utilities do
     |> Base.encode16
   end
 
-
   @doc """
     The merkle root lets us represent a large dataset using only one string. We can be confident that
     if any of the data changes, the merkle root will be different, which invalidates the dataset

--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -80,7 +80,7 @@ defmodule UltraDark.Validator do
   end
 
   defp appropriate_coinbase_output?([coinbase | transactions], block_index) do
-    if D.add(Block.total_block_fees(transactions), Block.calculate_block_reward(block_index)) == List.first(coinbase.outputs).amount, do: :ok, else: {:error, "Coinbase output is invalid"}
+    if D.equal?(D.add(Block.total_block_fees(transactions), Block.calculate_block_reward(block_index)), List.first(coinbase.outputs).amount), do: :ok, else: {:error, "Coinbase output is invalid"}
   end
 
   @spec valid_difficulty?(Block, number) :: :ok | {:error, String.t}

--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -79,7 +79,7 @@ defmodule UltraDark.Validator do
   end
 
   defp appropriate_coinbase_output?([coinbase | transactions], block_index) do
-    if Block.total_block_fees(transactions) + Block.calculate_block_reward(block_index) == List.first(coinbase.outputs).amount, do: :ok, else: {:error, "Coinbase output is invalid"}
+    if D.add(Block.total_block_fees(transactions), Block.calculate_block_reward(block_index)) == List.first(coinbase.outputs).amount, do: :ok, else: {:error, "Coinbase output is invalid"}
   end
 
   @spec valid_difficulty?(Block, number) :: :ok | {:error, String.t}

--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -2,6 +2,7 @@ defmodule UltraDark.Validator do
   alias UltraDark.Blockchain.Block
   alias UltraDark.Utilities
   alias UltraDark.KeyPair
+  alias Decimal, as: D
 
   @moduledoc """
     Responsible for implementing the consensus rules to all blocks and transactions

--- a/lib/validator.ex
+++ b/lib/validator.ex
@@ -80,7 +80,10 @@ defmodule UltraDark.Validator do
   end
 
   defp appropriate_coinbase_output?([coinbase | transactions], block_index) do
-    if D.equal?(D.add(Block.total_block_fees(transactions), Block.calculate_block_reward(block_index)), List.first(coinbase.outputs).amount), do: :ok, else: {:error, "Coinbase output is invalid"}
+    total_fees = Block.total_block_fees(transactions)
+    reward = Block.calculate_block_reward(block_index)
+    amount = List.first(coinbase.outputs).amount
+    if D.equal?(D.add(total_fees, reward), amount), do: :ok, else: {:error, "Coinbase output is invalid"}
   end
 
   @spec valid_difficulty?(Block, number) :: :ok | {:error, String.t}

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule UltraDark.Mixfile do
     [
       {:exleveldb, "~> 0.12.2"},
       {:keccakf1600, "~> 2.0.0"},
+      {:decimal, "~> 1.0"},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false}
     ]
   end

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -1,5 +1,6 @@
 defmodule BlockTest do
   alias UltraDark.Blockchain.Block
+  alias Decimal, as: D
   use ExUnit.Case, async: true
 
   test "can create a genesis block" do
@@ -74,30 +75,30 @@ defmodule BlockTest do
   end
 
   test "can correctly calculate block reward" do
-    assert Block.calculate_block_reward(1) == 100
-    assert Block.calculate_block_reward(200000) == 50
-    assert Block.calculate_block_reward(175000) == 100
-    assert Block.calculate_block_reward(3000000) == 0.0030517578125
+    assert D.equal? Block.calculate_block_reward(1), D.new(100)
+    assert D.equal? Block.calculate_block_reward(200000), D.new(50)
+    assert D.equal? Block.calculate_block_reward(175000), D.new(100)
+    assert D.equal? Block.calculate_block_reward(3000000), D.new(0.0030517578125)
   end
 
   test "can calculate block fees" do
-    transactions = [
+    _transactions = [
       %{
         inputs: [
-          %{txoid: "sometxoid", amount: 21},
-          %{txoid: "othertxoid", amount: 123.23}
+          %{txoid: "sometxoid", amount: D.new(21)},
+          %{txoid: "othertxoid", amount: D.new(123.23)}
         ],
         outputs: [
-          %{txoid: "atxoid", amount: 112},
+          %{txoid: "atxoid", amount: D.new(112)},
         ]
       },
       %{
         inputs: [
-          %{txoid: "bleh", amount: 1},
-          %{txoid: "meh", amount: 13}
+          %{txoid: "bleh", amount: D.new(1)},
+          %{txoid: "meh", amount: D.new(13)}
         ],
         outputs: [
-          %{txoid: "atxoid", amount:  14},
+          %{txoid: "atxoid", amount: D.new(14)},
         ]
       }
     ]

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -1,5 +1,6 @@
 defmodule BlockTest do
   alias UltraDark.Blockchain.Block
+  alias UltraDark.Transaction
   alias Decimal, as: D
   use ExUnit.Case, async: true
 
@@ -82,8 +83,8 @@ defmodule BlockTest do
   end
 
   test "can calculate block fees" do
-    _transactions = [
-      %{
+    transactions = [
+      %Transaction{
         inputs: [
           %{txoid: "sometxoid", amount: D.new(21)},
           %{txoid: "othertxoid", amount: D.new(123.23)}
@@ -92,7 +93,7 @@ defmodule BlockTest do
           %{txoid: "atxoid", amount: D.new(112)},
         ]
       },
-      %{
+      %Transaction{
         inputs: [
           %{txoid: "bleh", amount: D.new(1)},
           %{txoid: "meh", amount: D.new(13)}
@@ -103,9 +104,6 @@ defmodule BlockTest do
       }
     ]
 
-    # TODO -- we need to represent shades as decimal instead of float because of
-    # float arithmetic precision errors in the stdlib
-
-    # assert Block.total_block_fees(transactions) ==
+    assert D.equal? Block.total_block_fees(transactions), D.new(158.23)
   end
 end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -1,5 +1,6 @@
 defmodule TransactionTest do
   alias UltraDark.Transaction
+  alias Decimal, as: D
   use ExUnit.Case, async: true
 
   test "can generate a coinbase transaction" do
@@ -31,29 +32,29 @@ defmodule TransactionTest do
   test "can generate outputs from designations" do
     tx = %Transaction{
       inputs: [
-        %{txoid: "wfwe1d:0", amount: 123.12},
-        %{txoid: "wfwe1d:4", amount: 31.33},
-        %{txoid: "wfwe1d:1", amount: 18}
+        %{txoid: "wfwe1d:0", amount: D.new(123.12)},
+        %{txoid: "wfwe1d:4", amount: D.new(31.33)},
+        %{txoid: "wfwe1d:1", amount: D.new(18)}
       ],
       designations: [
-        %{addr: "reciever1", amount: 3},
-        %{addr: "reciever2", amount: 132}
+        %{addr: "reciever1", amount: D.new(3)},
+        %{addr: "reciever2", amount: D.new(132)}
       ]
     }
 
     tx = %{tx | id: Transaction.calculate_hash(tx)}
 
     expected_outputs =  %{
-      fee: 37.44999999999999,
+      fee: D.new(37.45),
       outputs: [
         %{
           addr: "reciever1",
-          amount: 3,
+          amount: D.new(3),
           txoid: "03E4C4FC8EFCB9F5C03CA73E9A7AA3D60A258B5FC52D7A75C7D0DEF69322A93F:0"
         },
         %{
           addr: "reciever2",
-          amount: 132,
+          amount: D.new(132),
           txoid: "03E4C4FC8EFCB9F5C03CA73E9A7AA3D60A258B5FC52D7A75C7D0DEF69322A93F:1"
         }
       ]


### PR DESCRIPTION
This pull request changes the calculations on transactions to use the `Decimal` type from the Decimal library, instead of primitive Elixir floats, to improve precision of transactions.

Parts of the other repositories will have to be changed: certainly the wallet app and probably the miner app too.

Fixes #27 